### PR TITLE
continue if an asset file is missing

### DIFF
--- a/packager/packaging.py
+++ b/packager/packaging.py
@@ -64,7 +64,10 @@ def pack_artifact(artifact, src_dir, dst_dir):
                     os.makedirs(os.path.join(dst_dir, os.path.dirname(item.text)))
                 except OSError:
                     pass
-                shutil.copyfile(os.path.join(src_dir, item.text), os.path.join(dst_dir, item.text))
+                try:
+                    shutil.copyfile(os.path.join(src_dir, item.text), os.path.join(dst_dir, item.text))
+                except IOError:
+                    logger.warning("Addon %s asset %s is missing.", artifact.addon_id, item.text)
     else:  # for backwards compatibility with add-ons that do not use the assets element
         if os.path.exists(os.path.join(src_dir, "icon.png")):
             shutil.copyfile(os.path.join(src_dir, "icon.png"), os.path.join(dst_dir, "icon.png"))


### PR DESCRIPTION
e.g. https://github.com/xbmc/repo-scripts/blob/debfb65/script.reddit.reader/addon.xml#L33 has a wrong filename therefore all other asserts also not copied, because function stops with an error.
With this fix at least all existing files will be copied.