### PR TITLE
fix handling of zipfile exception

### DIFF
--- a/packager/binarypackaging.py
+++ b/packager/binarypackaging.py
@@ -63,7 +63,7 @@ def collect_artifacts(binary_repos, min_versions):
                             except (ET.ParseError, KeyError, IndexError) as e:
                                 logging.exception("Failed to read addon info from '%s'. Skipping" % archive)
                                 continue
-                    except zipfile.BadZipFile as e:
+                    except zipfile.BadZipfile as e:
                         logging.exception("Zip file is corrupted")
                         continue
 


### PR DESCRIPTION
in https://github.com/xbmc/repository-generator/pull/10 we added some code to handle zipfile exceptions.
as it turns out, it contained a typo that prevents it from working correctly.
the script would still crash when it encounters a corrupt zipfile.

that is fixed now.