### PR TITLE
fix parsing versions by using regex and handling errors

### DIFF
--- a/packager/packaging.py
+++ b/packager/packaging.py
@@ -41,7 +41,11 @@ def update_changed_artifacts(git_repos, refs, binary_repos, min_versions, outdir
     removed = current - set(artifacts)
     for artifact_id in removed:
         logger.debug("Removing artifact %s", artifact_id)
-        shutil.rmtree(os.path.join(outdir, artifact_id))
+        try:
+            shutil.rmtree(os.path.join(outdir, artifact_id))
+        except (OSError) as e:
+            logger.error("Error removing artifact: %s", e)
+            continue
 
     return added, len(removed)
 

--- a/update_indexes.py
+++ b/update_indexes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 #
 #     Copyright (C) 2015 Team Kodi

--- a/updaterepo.py
+++ b/updaterepo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 #
 #     Copyright (C) 2015 Team Kodi


### PR DESCRIPTION
fixes errors when ZIPs with "invalid" names exist, e.g. pvr.waipu-2.3.0-backported.zip
Such zip files cause the entire addon to be omitted in in the addon.xml, due to exceptions in parsing the version. 