### PR TITLE
Make path to TexturePacker configurable

### DIFF
--- a/example.cfg
+++ b/example.cfg
@@ -1,6 +1,7 @@
 [general]
 destination = /mnt/disk1/addons/
 version_to_keep = 3
+texturepacker = /mnt/disk1/xbmc/tools/depends/native/TexturePacker/x86_64-linux-native/TexturePacker
 
 [debug]
 level = 10

--- a/packager/textures.py
+++ b/packager/textures.py
@@ -21,6 +21,7 @@ import logging
 import subprocess
 
 logger = logging.getLogger(__name__)
+texturepacker_binary = 'TexturePacker'
 
 
 def pack_textures(xml, working_dir):
@@ -56,6 +57,13 @@ def remove_non_xbt_files(directory):
 
 def run_texturepacker(input, output):
     logger.debug("Running texturepacker on %s ...", input)
-    cmd = ['TexturePacker', '-dupecheck', '-input', input, '-output', output]
+    cmd = [texturepacker_binary, '-dupecheck', '-input', input, '-output', output]
     with open(os.devnull, 'w') as f:
         subprocess.check_call(cmd, stdout=f, stderr=f)
+
+def check_texturepacker():
+    with open(os.devnull, 'w') as f:
+        try:
+            return subprocess.call([texturepacker_binary], stdout=f, stderr=f) == 1
+        except:
+            return False

--- a/updaterepo.py
+++ b/updaterepo.py
@@ -23,6 +23,7 @@ import git
 import sys
 import logging
 import packager
+import packager.textures
 from distutils.version import LooseVersion
 from io import BytesIO
 
@@ -120,6 +121,17 @@ def main():
     filename = sys.argv[1] if len(sys.argv) > 1 else os.path.join(os.path.dirname(__file__), 'config.cfg')
     if not config.read(filename):
         print("Fatal: Could not read config file '%s'" % filename)
+        sys.exit(1)
+
+    try:
+        texturepacker_override = config.get('general', 'texturepacker')
+    except:
+        texturepacker_override = ""
+
+    if texturepacker_override:
+        packager.textures.texturepacker_binary = texturepacker_override
+    if not packager.textures.check_texturepacker():
+        print("Fatal: Could not invoke TexturePacker with command '%s'" % packager.textures.texturepacker_binary)
         sys.exit(1)
 
     logging.basicConfig(level=config.getint('debug', 'level'), format='%(levelname)s [%(name)s] %(message)s')


### PR DESCRIPTION
Don't want to have to install TexturePacker to /usr/bin on mirrors