### PR TITLE
Don't write addons.xml if contents have not changed

### DIFF
--- a/indexer/indexer.py
+++ b/indexer/indexer.py
@@ -109,8 +109,21 @@ def create_index(repo_dir, dest, prettify=False):
     if prettify:
         xml = minidom.parseString(xml).toprettyxml(encoding='utf-8', indent="  ")
 
-    with open(dest, 'wb') as f:
-        f.write(xml)
+    no_change = False
+    try:
+        with open(dest, 'rb') as f:
+            no_change = (xml == f.read())
+    except IOError:
+        pass
 
-    with gzip.GzipFile(dest + ".gz", 'wb', compresslevel=9, mtime=0) as f:
-        f.write(xml)
+    if no_change:
+        logging.info("Contents not changed, not touching {}".format(dest))
+    else:
+        logging.info("Writing {}".format(dest))
+        with open(dest, 'wb') as f:
+            f.write(xml)
+
+        with gzip.GzipFile(dest + ".gz", 'wb', compresslevel=9, mtime=0) as f:
+            f.write(xml)
+
+    return not no_change

--- a/update_indexes.py
+++ b/update_indexes.py
@@ -33,7 +33,12 @@ if not config.read('config.cfg'):
 
 if __name__ == '__main__':
     outdir = config.get('general', 'destination')
+    file_changed = False
     for target_name in os.listdir(outdir):
         target_path = os.path.join(outdir, target_name)
         if os.path.isdir(target_path):
-            indexer.create_index(target_path, os.path.join(target_path, "addons.xml"))
+            file_changed |= indexer.create_index(target_path, os.path.join(target_path, "addons.xml"))
+
+    if not file_changed:
+        # Special exit code 64 indicates that no files were changed
+        sys.exit(64)


### PR DESCRIPTION
This should prohibit mirrorbits from detecting the addons.xml as
changed/outdated and going to fallback servers every half an hour.